### PR TITLE
Bump pytest 8.3.4 -> 9.0.3 (dependabot alert #37)

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pytest==8.3.4
+pytest==9.0.3
 pytest-cov==6.0.0
 pytest-mock==3.14.0
 pytest-xdist==3.8.0


### PR DESCRIPTION
## Summary

Resolves dependabot alert #37: `pytest < 9.0.3` has a medium-severity **vulnerable tmpdir handling** issue. Bumps the pin in `requirements_dev.txt` to the patched `9.0.3`.

- **Scope:** dev/test-only dependency — not in the Lambda/production runtime path, so real-world exposure is low. Still worth clearing the alert.
- **Major version bump** (8.x → 9.x), so verified rather than assumed safe.

## Verification
- `pip install --dry-run pytest==9.0.3` resolves cleanly against the pinned plugins (`pytest-cov`, `pytest-xdist`, `pytest-mock`, `moto`) — no cascade required.
- Full suite on pytest 9.0.3: **296 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)