### PR TITLE
Momentum (Stage C / M4): cross-day story identity, 14-day rollup, seeded backfill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,15 +131,27 @@ See `docs/MONITORING_DASHBOARD.md` for complete documentation.
    - Emits `stories.json` beside `latest_news.json`; fallback headlines only
      (LLM naming is Stage B, not yet implemented)
 
-5. **Visualization** (`newvelles/display/show.py`)
+5. **Momentum** (`newvelles/models/momentum.py`)
+   - Carries story identity across runs/days: Jaccard over keywords ∪ entities
+     (>= 0.4) against stories last seen today/yesterday; a match inherits the
+     previous story id
+   - Maintains a rolling 14-day series per story (per-day datapoint = max
+     outlets/articles across that day's runs; only the current day mutates)
+   - Emits `momentum.json` (public, only live stories) and keeps
+     `momentum_state.json` (private, full window); both ride the sanity gate
+   - Trend vocabulary is a UI contract: new | climbing | peaked | cooling | steady
+   - Seed after a gap with `make backfill-momentum ENV=qa|prod` (replays the
+     production archive)
+
+6. **Visualization** (`newvelles/display/show.py`)
    - Generates JSON output with grouped news structure
    - Schema version: 0.2.1 (defined in `VISUALIZATION_VERSION`)
 
-6. **S3 Upload** (`newvelles/utils/s3.py`, `newvelles/feed/log.py`)
+7. **S3 Upload** (`newvelles/utils/s3.py`, `newvelles/feed/log.py`)
    - Single emit path: `emit_visualization()` with writer strategy (`local`/`s3`/`both`);
      `log_visualization`/`log_s3` are thin wrappers
    - Private bucket: timestamped visualization runs
-   - Public bucket: `latest_news.json`, `latest_news_metadata.json`, `stories.json`
+   - Public bucket: `latest_news.json`, `latest_news_metadata.json`, `stories.json`, `momentum.json`
    - All uploads validated against JSON schemas in `schemas/`
 
 ### Entry Points
@@ -249,6 +261,8 @@ newvelles/
 - `schemas/latest_news_schema.json` - Visualization data schema
 - `schemas/latest_news_metadata_schema.json` - Metadata schema
 - `schemas/stories_schema.json` - Stories data schema (0.3.0); contract fixture in `test/fixtures/stories_v0.3.0.json`
+- `schemas/momentum_schema.json` - Momentum data schema (0.3.0); contract fixture in `test/fixtures/momentum_v0.3.0.json`
+- `newvelles/models/momentum.py` - Cross-day story identity + 14-day rollup
 
 ## Important Testing Notes
 

--- a/Makefile
+++ b/Makefile
@@ -540,6 +540,12 @@ rollback-prod:
 	@echo "🔄 Starting production rollback..."
 	./bin/rollback-production.sh
 
+# Seed momentum_state.json + momentum.json from archived production runs
+# (replays the last 14 days through the momentum pipeline). ENV=qa|prod.
+backfill-momentum:
+	@if [ -z "$(ENV)" ]; then echo "Usage: make backfill-momentum ENV=qa|prod"; exit 1; fi
+	@$(VENV_ACTIVATE) && python scripts/backfill_momentum.py --env $(ENV)
+
 # Restore the public latest_news.json from a timestamped private-bucket archive.
 # Pauses EventBridge so the next scheduled run doesn't immediately overwrite the
 # restore; resume with 'make resume-eventbridge' when the pipeline is fixed.

--- a/docs/superpowers/plans/2026-08-16-momentum-stage-c.md
+++ b/docs/superpowers/plans/2026-08-16-momentum-stage-c.md
@@ -1,0 +1,105 @@
+# Momentum (Stage C / M4) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give stories identity across runs and days, emit a public `momentum.json` (rolling 14-day series per live story), keep a private `momentum_state.json`, and seed both from the archive so sparklines aren't empty at launch.
+
+**Architecture:** A pure `apply_momentum(stories_data, state, today)` in `newvelles/models/momentum.py` rewrites story ids by carrying identity from the previous state (Jaccard over keywords∪entities ≥ 0.4 against stories last seen today/yesterday), maintains per-story day series (per-day datapoint = max over that day's runs), derives `peak_date`/`trend`, and returns `(stories', momentum_doc, state')`. State I/O lives beside it (S3 private bucket / local `./cache/`); uploads ride the existing `emit_visualization()` behind the same sanity gate as `stories.json`. A backfill script replays archived runs chronologically to seed QA and production.
+
+**Tech Stack:** Python 3.12, pytest, existing `read_json_from_s3`/`upload_to_s3`, no new dependencies.
+
+## Global Constraints
+
+- Contract: `test/fixtures/momentum_v0.3.0.json` — same field names/shape. `days_running == len(series)`.
+- `WINDOW_DAYS = 14`, `CARRY_THRESHOLD = 0.4` (spec: "start at 0.4"), `MOMENTUM_VERSION = "0.3.0"`.
+- Trend vocabulary is a UI contract: production emits only `new | climbing | peaked | cooling | steady`. Schema additionally tolerates the fixture-only `single day`.
+- Day datapoint rule: a day records its peak — `outlets = max(existing, run)`, `articles = max(existing, run)`; **only the current day is ever mutated**; earlier days are immutable once passed. Dates are UTC.
+- Identity: match only against state stories with `last_seen` ≥ yesterday; a match inherits the previous `id`; no match mints a new id. Matching is one-to-one, best-score-first.
+- Public `momentum.json` contains **only ids present in the current `stories.json`** (front end joins on id); the private state keeps the full window.
+- Momentum uploads and state save are gated by the same pre-publish sanity gate as `stories.json` — a blocked run must not pollute state.
+- `latest_news.json` byte-identical guarantee continues to hold.
+- Branch `redesign/momentum`, one commit per task.
+
+## File Structure
+
+- `newvelles/models/momentum.py` — new: pure core + state I/O helpers.
+- `newvelles/feed/log.py` — modified: emit momentum doc (public) + state (private) inside the gated branch; local writer variants.
+- `handler.py`, `newvelles/__main__.py` — modified: load state → `apply_momentum` → pass artifacts to emit.
+- `schemas/momentum_schema.json` — new.
+- `scripts/backfill_momentum.py`, `Makefile` (`backfill-momentum`) — new.
+- Tests: `test/test_models_momentum.py`, `test/test_momentum_schema.py`, additions to `test/test_feed_log.py`.
+
+---
+
+### Task 1: Pure momentum core (`apply_momentum`, trend, matching)
+
+**Files:** Create `newvelles/models/momentum.py`; Test `test/test_models_momentum.py`
+
+**Interfaces — Produces:**
+- `apply_momentum(stories_data: dict, state: Optional[dict], today: str) -> tuple[dict, dict, dict]` — returns `(stories_data_with_carried_ids, momentum_doc, new_state)`. Mutates story `id`, `days_running`, `first_seen` from carried identity.
+- `derive_trend(series: list, peak_date: str) -> str`
+- State shape: `{"version", "updated", "stories": {id: {"keywords": [], "entities": [], "first_seen", "last_seen", "series": [{"date","outlets","articles"}]}}}`
+- Momentum doc shape: `{"version", "generated", "window_days", "window_start", "window_end", "stories": {id: {"first_seen","days_running","series","peak_date","trend"}}}`
+
+Key test cases (write first, run red, implement, run green, commit):
+- Two consecutive days: story persists (id carried, `days_running` 2, series 2 entries), another dies (absent from doc; retained in state), a new one appears (fresh id, trend `new`).
+- Same-day second run: series stays 1 entry with `outlets/articles = max` of the two runs; id stable.
+- Story seen Mon, absent Tue, returns Wed → new id (matching window is yesterday only).
+- One-to-one matching: two current stories both similar to one previous story → only the better match carries the id.
+- Window: simulate 16 days → series never exceeds 14 entries; state prunes stories with `last_seen` older than the window.
+- Trend: single entry → `new`; rising last day ≥ mean → `climbing`; drop right after the peak (peak == yesterday) → `peaked`; below-mean decline → `cooling`; flat → `steady`. `peak_date` = earliest date with max outlets.
+- Doc contains only current story ids; `window_start = today − 13d`, `window_end = today`.
+- `state=None` behaves as first run.
+
+Trend rule (implement exactly):
+```python
+def derive_trend(series, peak_date):
+    if len(series) == 1:
+        return "new"
+    last, prev = series[-1]["outlets"], series[-2]["outlets"]
+    window_mean = sum(p["outlets"] for p in series) / len(series)
+    if last > prev and last >= window_mean:
+        return "climbing"
+    if peak_date == series[-2]["date"] and last < prev:
+        return "peaked"
+    if last < prev and last < window_mean:
+        return "cooling"
+    return "steady"
+```
+
+Signature for matching: `set(story["keywords"]) | {e.lower() for e in story["entities"]}`; Jaccard `|A∩B| / |A∪B|`; candidates from state where `last_seen >= today - 1 day`; pairs sorted by score desc, each previous id assigned at most once, threshold `>= CARRY_THRESHOLD`.
+
+### Task 2: Momentum schema + fixture validation
+
+**Files:** Create `schemas/momentum_schema.json`; Test `test/test_momentum_schema.py`
+
+- Draft-07, style of the existing schemas. Required top-level: `version` (`^0\.3\.\d+$`), `generated`, `window_days`, `stories`; optional `window_start`, `window_end`, `approximation*` (fixture provenance). Story: required `first_seen`, `days_running` (min 1), `series` (minItems 1, items require `date`/`outlets`/`articles`), `peak_date`, `trend` (enum: new, climbing, peaked, cooling, steady, `single day`).
+- Tests: fixture validates; a generated doc (from Task 1's synthetic two-day scenario) validates; missing `trend` rejected; bad trend value rejected.
+
+### Task 3: State I/O + emit wiring + handler/CLI
+
+**Files:** Modify `newvelles/models/momentum.py` (I/O helpers), `newvelles/feed/log.py`, `handler.py`, `newvelles/__main__.py`; Test additions to `test/test_feed_log.py`
+
+- `momentum.py` I/O: `load_state_s3()` (private bucket via `read_json_from_s3`), `load_state_local(path="./cache/momentum_state.json")`. Saving happens through the emit path so it shares the gate.
+- `log.py`: constants `_LOG_MOMENTUM_NAME = "momentum"`, `_MOMENTUM_STATE_NAME = "momentum_state"`. `emit_visualization(..., momentum_doc=None, momentum_state=None)`; inside the gate-passing branch of `_emit_stories` (rename to `_emit_stories_and_momentum`): after `stories.json`, upload `momentum.json` (public, `public_read=True`) and `momentum_state.json` (**private** bucket). Local writer: `./momentum.json`, `{_LATEST_PATH}/momentum.json`, and state to `./cache/momentum_state.json` (mkdir). Gate blocked → none of stories/momentum/state written to S3 (locals still written).
+- `log_s3(visualization_data, stories_data=None, momentum_doc=None, momentum_state=None)` passthrough.
+- `handler.py`: `state = load_state_s3()`; `stories_data, momentum_doc, new_state = apply_momentum(stories_data, state, today=utc_today())`; pass all three to `log_s3`; print carried-id count (monitoring: "stories with carried ids" catches identity churn).
+- `__main__.py`: same with `load_state_local()`.
+- Tests: upload order/buckets (4th = stories.json public, 5th = momentum.json public, 6th = momentum_state.json private); blocked gate → 3 uploads only; local writer writes momentum + state files; `log_s3` delegation.
+
+### Task 4: Backfill script + seed QA (and production)
+
+**Files:** Create `scripts/backfill_momentum.py`; Modify `Makefile` (`backfill-momentum` target)
+
+- Script: list private bucket archives (`newvelles_visualization_0.2.1_*`), keep runs whose UTC date is within the last `WINDOW_DAYS`, dedupe near-duplicates, process chronologically: download → `build_stories(viz)` → `apply_momentum(..., today=run_date)` threading the state. Then upload `momentum_state.json` (private) + `momentum.json` (public) — `--dry-run` writes to local files instead. `--env qa|prod` selects bucket pairs (qa: `newvelles-qa-bucket`/`public-newvelles-qa-bucket`).
+- Makefile: `backfill-momentum: python scripts/backfill_momentum.py --env $(ENV)`.
+- Execute: dry-run on prod archives first (inspect output sanity: carried ids exist, series lengths > 1 for persistent stories), then seed **QA** buckets (M4's done-when), then seed **production** buckets (producer-before-consumer: file sits unused until M5).
+
+### Task 5: Docs, suite, PR
+
+- `CLAUDE.md`: momentum stage bullet in Core Data Flow; `momentum.json`/`momentum_state.json` in S3 upload list; key files.
+- Full suite + lint; push `redesign/momentum`; PR.
+
+## Self-Review notes
+- Spec coverage: identity match (§4 match_previous, threshold 0.4) ✓; rollup shape ✓; max-per-day rule + current-day-only mutation ✓; trend derived not stored ✓ vocabulary contract ✓; backfill seeding ✓ (M4 done-when includes the seeded window); gate interaction defined (not in spec — decision recorded: anomalous runs must not pollute identity state).
+- Deviation from spec noted for review: public momentum.json filtered to current stories (keeps the file small and matches the fixture, which carries exactly the 41 current stories).

--- a/handler.py
+++ b/handler.py
@@ -9,6 +9,7 @@ from newvelles.config import config
 from newvelles.feed.load import build_data_from_rss_feeds, build_data_from_rss_feeds_list
 from newvelles.feed.log import log_s3
 from newvelles.models.grouping import build_visualization
+from newvelles.models.momentum import apply_momentum, load_state_s3, utc_today
 from newvelles.models.stories import build_stories
 
 
@@ -85,8 +86,18 @@ def run() -> bool:
           f"({kind_counts.get('story', 0)} story / {kind_counts.get('roundup', 0)} roundup / "
           f"{kind_counts.get('deal', 0)} deal) from {len(visualization_data)} groups")
 
+    print("📈 Applying momentum (identity carry + rolling window)...")
+    momentum_state = load_state_s3()
+    stories_data, momentum_doc, new_state = apply_momentum(
+        stories_data, momentum_state, today=utc_today()
+    )
+    carried = sum(1 for s in stories_data["stories"] if s.get("days_running", 1) > 1)
+    print(f"📈 {carried} stories carried an id from a previous day "
+          f"({len(momentum_doc['stories'])} in the momentum window)")
+
     print("📤 Uploading to S3...")
-    log_s3(visualization_data, stories_data=stories_data)
+    log_s3(visualization_data, stories_data=stories_data,
+           momentum_doc=momentum_doc, momentum_state=new_state)
     print("✅ S3 upload completed successfully")
     
     return True

--- a/newvelles/__main__.py
+++ b/newvelles/__main__.py
@@ -8,6 +8,7 @@ from newvelles.display.show import print_sorted_grouped_titles, print_viz
 from newvelles.feed.load import build_data_from_rss_feeds
 from newvelles.feed.log import emit_visualization, log_groups
 from newvelles.models.grouping import build_visualization
+from newvelles.models.momentum import apply_momentum, load_state_local, utc_today
 from newvelles.models.stories import build_stories
 
 CONFIG = config()
@@ -21,11 +22,16 @@ def run(rss_file: str, s3: bool) -> None:
         title_data, cluster_limit=cluster_limit
     )
     stories_data = build_stories(visualization_data)
+    stories_data, momentum_doc, momentum_state = apply_momentum(
+        stories_data, load_state_local(), today=utc_today()
+    )
     # log data
     emit_visualization(
         visualization_data,
         writers="both" if s3 else "local",
         stories_data=stories_data,
+        momentum_doc=momentum_doc,
+        momentum_state=momentum_state,
     )
     log_groups(group_sentences)
 

--- a/newvelles/feed/log.py
+++ b/newvelles/feed/log.py
@@ -18,6 +18,9 @@ _LOG_VISUALIZATION_NAME = "newvelles_visualization"
 _LOG_LATEST_VISUALIZATION_NAME = "latest_news"
 _LOG_LATEST_VISUALIZATION_METADATA_NAME = "latest_news_metadata"
 _LOG_STORIES_NAME = "stories"
+_LOG_MOMENTUM_NAME = "momentum"
+_MOMENTUM_STATE_NAME = "momentum_state"
+_LOCAL_STATE_DIR = "./cache"
 
 # Load S3 bucket names from config with fallbacks
 CONFIG = config()
@@ -89,6 +92,8 @@ def emit_visualization(
     writers: str = "local",
     output_path: str = _LOG_PATH,
     stories_data=None,
+    momentum_doc=None,
+    momentum_state=None,
 ) -> str:
     """Single emit path for visualization outputs.
 
@@ -152,12 +157,14 @@ def emit_visualization(
         )
 
     if stories_data is not None:
-        _emit_stories(stories_data, write_local=write_local, write_s3=write_s3)
+        _emit_stories(stories_data, write_local=write_local, write_s3=write_s3,
+                      momentum_doc=momentum_doc, momentum_state=momentum_state)
 
     return log_path if write_local else timestamped_name
 
 
-def _emit_stories(stories_data, write_local: bool, write_s3: bool) -> None:
+def _emit_stories(stories_data, write_local: bool, write_s3: bool,
+                  momentum_doc=None, momentum_state=None) -> None:
     if write_local:
         for stories_path in (
             f"{_LATEST_PATH}/{_LOG_STORIES_NAME}.json",
@@ -165,15 +172,30 @@ def _emit_stories(stories_data, write_local: bool, write_s3: bool) -> None:
         ):
             with open(stories_path, "w", encoding="utf-8") as f:
                 json.dump(stories_data, f)
+        if momentum_doc is not None:
+            for momentum_path in (
+                f"{_LATEST_PATH}/{_LOG_MOMENTUM_NAME}.json",
+                f"./{_LOG_MOMENTUM_NAME}.json",
+            ):
+                with open(momentum_path, "w", encoding="utf-8") as f:
+                    json.dump(momentum_doc, f)
+        if momentum_state is not None:
+            os.makedirs(_LOCAL_STATE_DIR, exist_ok=True)
+            with open(f"{_LOCAL_STATE_DIR}/{_MOMENTUM_STATE_NAME}.json", "w",
+                      encoding="utf-8") as f:
+                json.dump(momentum_state, f)
     if write_s3:
         # Pre-publish sanity gate: compare against the previously published
-        # run and refuse to overwrite it with an anomalous one.
+        # run and refuse to overwrite it with an anomalous one. Momentum and
+        # its identity state ride the same gate — an anomalous run must not
+        # pollute cross-day story identity.
         previous = read_json_from_s3(_S3_PUBLIC_BUCKET, f"{_LOG_STORIES_NAME}.json")
         previous_count = previous.get("story_count") if previous else None
         ok, reason = evaluate_stories_gate(stories_data, previous_count)
         if not ok:
             print(f"❌ Stories sanity gate blocked publish: {reason}")
-            print("   Previous stories.json left in place; legacy files published normally.")
+            print("   Previous stories.json/momentum.json left in place; "
+                  "legacy files published normally.")
             return
         upload_to_s3(
             bucket_name=_S3_PUBLIC_BUCKET,
@@ -181,6 +203,19 @@ def _emit_stories(stories_data, write_local: bool, write_s3: bool) -> None:
             string_byte=json.dumps(stories_data).encode("utf-8"),
             public_read=True,
         )
+        if momentum_doc is not None:
+            upload_to_s3(
+                bucket_name=_S3_PUBLIC_BUCKET,
+                file_name=f"{_LOG_MOMENTUM_NAME}.json",
+                string_byte=json.dumps(momentum_doc).encode("utf-8"),
+                public_read=True,
+            )
+        if momentum_state is not None:
+            upload_to_s3(
+                bucket_name=_S3_BUCKET,
+                file_name=f"{_MOMENTUM_STATE_NAME}.json",
+                string_byte=json.dumps(momentum_state).encode("utf-8"),
+            )
 
 
 def log_visualization(visualization_data, output_path: str = _LOG_PATH, s3: bool = False) -> str:
@@ -191,5 +226,6 @@ def log_visualization(visualization_data, output_path: str = _LOG_PATH, s3: bool
     )
 
 
-def log_s3(visualization_data, stories_data=None) -> str:
-    return emit_visualization(visualization_data, writers="s3", stories_data=stories_data)
+def log_s3(visualization_data, stories_data=None, momentum_doc=None, momentum_state=None) -> str:
+    return emit_visualization(visualization_data, writers="s3", stories_data=stories_data,
+                              momentum_doc=momentum_doc, momentum_state=momentum_state)

--- a/newvelles/feed/log.py
+++ b/newvelles/feed/log.py
@@ -87,8 +87,9 @@ def log_groups(
     # Note: Actual outputs are handled by log_s3() which uploads directly to S3
 
 
-def emit_visualization(
+def emit_visualization(  # pylint: disable=too-many-arguments
     visualization_data,
+    *,
     writers: str = "local",
     output_path: str = _LOG_PATH,
     stories_data=None,

--- a/newvelles/models/momentum.py
+++ b/newvelles/models/momentum.py
@@ -1,0 +1,161 @@
+"""Story identity across runs and days, and the rolling 14-day momentum rollup.
+
+Links can't carry identity across days — tomorrow's coverage of the same story
+is entirely new articles. Identity is matched on content overlap instead:
+Jaccard over keywords ∪ entities against stories last seen today or yesterday.
+A match inherits the previous story id; no match mints a new one.
+
+Per-day datapoints record a day's peak (max outlets/articles across that day's
+runs); only the current day is ever mutated. The public momentum.json carries
+only stories present in the current stories.json; the private state keeps the
+full window.
+"""
+from datetime import date, timedelta
+from typing import Optional, Tuple
+
+MOMENTUM_VERSION = "0.3.0"
+WINDOW_DAYS = 14
+CARRY_THRESHOLD = 0.4
+
+
+def _signature(story: dict) -> set:
+    return set(story.get("keywords", [])) | {e.lower() for e in story.get("entities", [])}
+
+
+def _jaccard(a: set, b: set) -> float:
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def _empty_state() -> dict:
+    return {"version": MOMENTUM_VERSION, "updated": "", "stories": {}}
+
+
+def _match_previous(stories: list, state: dict, today: str) -> dict:
+    """One-to-one assignment of current stories to carryable previous ids.
+
+    Returns {current_index: previous_id}. Candidates are previous stories last
+    seen today (earlier run) or yesterday; pairs are assigned best-score-first.
+    """
+    yesterday = (date.fromisoformat(today) - timedelta(days=1)).isoformat()
+    candidates = {
+        prev_id: _signature(entry)
+        for prev_id, entry in state["stories"].items()
+        if entry["last_seen"] >= yesterday
+    }
+    scored = []
+    for idx, story in enumerate(stories):
+        sig = _signature(story)
+        for prev_id, prev_sig in candidates.items():
+            score = _jaccard(sig, prev_sig)
+            if score >= CARRY_THRESHOLD:
+                scored.append((score, idx, prev_id))
+    scored.sort(reverse=True)
+
+    assigned: dict = {}
+    used_prev: set = set()
+    for _score, idx, prev_id in scored:
+        if idx in assigned or prev_id in used_prev:
+            continue
+        assigned[idx] = prev_id
+        used_prev.add(prev_id)
+    return assigned
+
+
+def derive_trend(series: list, peak_date: str) -> str:
+    """One of: new | climbing | peaked | cooling | steady. The vocabulary is a
+    UI contract — the front end prints it verbatim under the sparkline."""
+    if len(series) == 1:
+        return "new"
+    last, prev = series[-1]["outlets"], series[-2]["outlets"]
+    window_mean = sum(p["outlets"] for p in series) / len(series)
+    if last > prev and last >= window_mean:
+        return "climbing"
+    if peak_date == series[-2]["date"] and last < prev:
+        return "peaked"
+    if last < prev and last < window_mean:
+        return "cooling"
+    return "steady"
+
+
+def _peak_date(series: list) -> str:
+    peak = max(p["outlets"] for p in series)
+    return next(p["date"] for p in series if p["outlets"] == peak)
+
+
+def apply_momentum(
+    stories_data: dict, state: Optional[dict], today: str
+) -> Tuple[dict, dict, dict]:
+    """Carry story identity, update the rolling state, and derive momentum.json.
+
+    Returns (stories_data with carried ids/days_running/first_seen,
+             momentum_doc, new_state). stories_data is mutated in place.
+    """
+    state = state or _empty_state()
+    window_start = (date.fromisoformat(today) - timedelta(days=WINDOW_DAYS - 1)).isoformat()
+    stories = stories_data.get("stories", [])
+    carried = _match_previous(stories, state, today)
+
+    new_state_stories: dict = {}
+    for idx, story in enumerate(stories):
+        story_id = carried.get(idx, story["id"])
+        previous = state["stories"].get(story_id) if idx in carried else None
+
+        series = list(previous["series"]) if previous else []
+        datapoint = {"date": today, "outlets": story["outlet_count"],
+                     "articles": story["article_count"]}
+        if series and series[-1]["date"] == today:
+            # a later run on the same day: the day records its peak
+            series[-1] = {
+                "date": today,
+                "outlets": max(series[-1]["outlets"], datapoint["outlets"]),
+                "articles": max(series[-1]["articles"], datapoint["articles"]),
+            }
+        else:
+            series.append(datapoint)
+        series = [p for p in series if p["date"] >= window_start]
+
+        first_seen = previous["first_seen"] if previous else today
+        story["id"] = story_id
+        story["first_seen"] = first_seen
+        story["days_running"] = len(series)
+        new_state_stories[story_id] = {
+            "keywords": story.get("keywords", []),
+            "entities": story.get("entities", []),
+            "first_seen": first_seen,
+            "last_seen": today,
+            "series": series,
+        }
+
+    # retain previous stories not seen today while they remain inside the window
+    for prev_id, entry in state["stories"].items():
+        if prev_id in new_state_stories:
+            continue
+        trimmed = [p for p in entry["series"] if p["date"] >= window_start]
+        if entry["last_seen"] >= window_start and trimmed:
+            new_state_stories[prev_id] = {**entry, "series": trimmed}
+
+    new_state = {"version": MOMENTUM_VERSION, "updated": today, "stories": new_state_stories}
+
+    momentum_stories = {}
+    for story in stories:
+        entry = new_state_stories[story["id"]]
+        peak = _peak_date(entry["series"])
+        momentum_stories[story["id"]] = {
+            "first_seen": entry["first_seen"],
+            "days_running": len(entry["series"]),
+            "series": entry["series"],
+            "peak_date": peak,
+            "trend": derive_trend(entry["series"], peak),
+        }
+
+    momentum_doc = {
+        "version": MOMENTUM_VERSION,
+        "generated": stories_data.get("generated", today),
+        "window_days": WINDOW_DAYS,
+        "window_start": window_start,
+        "window_end": today,
+        "stories": momentum_stories,
+    }
+    return stories_data, momentum_doc, new_state

--- a/newvelles/models/momentum.py
+++ b/newvelles/models/momentum.py
@@ -10,12 +10,36 @@ runs); only the current day is ever mutated. The public momentum.json carries
 only stories present in the current stories.json; the private state keeps the
 full window.
 """
-from datetime import date, timedelta
+import json
+from datetime import date, timedelta, timezone
+from datetime import datetime as _datetime
 from typing import Optional, Tuple
 
 MOMENTUM_VERSION = "0.3.0"
 WINDOW_DAYS = 14
 CARRY_THRESHOLD = 0.4
+LOCAL_STATE_PATH = "./cache/momentum_state.json"
+
+
+def utc_today() -> str:
+    """Momentum days are UTC — matching the archive timestamps and the Lambda."""
+    return _datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def load_state_s3() -> Optional[dict]:
+    """Read momentum_state.json from the private bucket; None on first run."""
+    from newvelles.feed.log import _MOMENTUM_STATE_NAME, _S3_BUCKET
+    from newvelles.utils.s3 import read_json_from_s3
+    return read_json_from_s3(_S3_BUCKET, f"{_MOMENTUM_STATE_NAME}.json")
+
+
+def load_state_local(path: str = LOCAL_STATE_PATH) -> Optional[dict]:
+    """Read the local momentum state; None on first run or unreadable file."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return None
 
 
 def _signature(story: dict) -> set:

--- a/newvelles/models/momentum.py
+++ b/newvelles/models/momentum.py
@@ -28,8 +28,11 @@ def utc_today() -> str:
 
 def load_state_s3() -> Optional[dict]:
     """Read momentum_state.json from the private bucket; None on first run."""
-    from newvelles.feed.log import _MOMENTUM_STATE_NAME, _S3_BUCKET
-    from newvelles.utils.s3 import read_json_from_s3
+    # Imported lazily: feed.log resolves bucket names from env/config at import
+    # time, and tests monkeypatch them there — resolving at call time keeps the
+    # patched values visible.
+    from newvelles.feed.log import _MOMENTUM_STATE_NAME, _S3_BUCKET  # pylint: disable=import-outside-toplevel
+    from newvelles.utils.s3 import read_json_from_s3  # pylint: disable=import-outside-toplevel
     return read_json_from_s3(_S3_BUCKET, f"{_MOMENTUM_STATE_NAME}.json")
 
 

--- a/schemas/momentum_schema.json
+++ b/schemas/momentum_schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Newvelles Momentum Schema",
+  "description": "Schema for momentum.json (version 0.3.0) - rolling 14-day series per live story",
+  "type": "object",
+  "required": ["version", "generated", "window_days", "stories"],
+  "properties": {
+    "version": {"type": "string", "pattern": "^0\\.3\\.\\d+$"},
+    "generated": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}$"},
+    "window_days": {"type": "integer", "minimum": 1},
+    "window_start": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$"},
+    "window_end": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$"},
+    "approximation": {"type": "boolean"},
+    "approximation_note": {"type": "string"},
+    "stories": {
+      "type": "object",
+      "propertyNames": {"pattern": "^st_[0-9a-f]{6}$"},
+      "additionalProperties": {
+        "type": "object",
+        "required": ["first_seen", "days_running", "series", "peak_date", "trend"],
+        "properties": {
+          "first_seen": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$"},
+          "days_running": {"type": "integer", "minimum": 1},
+          "series": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["date", "outlets", "articles"],
+              "properties": {
+                "date": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$"},
+                "outlets": {"type": "integer", "minimum": 0},
+                "articles": {"type": "integer", "minimum": 0}
+              }
+            }
+          },
+          "peak_date": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$"},
+          "trend": {
+            "type": "string",
+            "enum": ["new", "climbing", "peaked", "cooling", "steady", "single day"],
+            "description": "UI contract, printed verbatim under the sparkline. Production emits new|climbing|peaked|cooling|steady; 'single day' appears only in the approximated fixture."
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/backfill_momentum.py
+++ b/scripts/backfill_momentum.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+"""Seed momentum_state.json and momentum.json from archived production runs.
+
+Replays the last WINDOW_DAYS days of archived visualization runs through the
+same build_stories -> apply_momentum pipeline the Lambda uses, then uploads
+the seeded state (private bucket) and rollup (public bucket). Without this,
+every story reads "new today" for the first fortnight and the sparkline
+column is empty at launch.
+
+Usage:
+    python scripts/backfill_momentum.py --env qa --dry-run
+    python scripts/backfill_momentum.py --env qa
+    python scripts/backfill_momentum.py --env prod
+
+The source archive is always the production private bucket (the QA Lambda
+runs rarely, so its archive cannot seed a realistic window); --env selects
+the destination buckets only.
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import boto3
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from newvelles.models.momentum import WINDOW_DAYS, apply_momentum  # noqa: E402
+from newvelles.models.stories import build_stories  # noqa: E402
+from newvelles.utils.s3 import upload_to_s3  # noqa: E402
+
+SOURCE_ARCHIVE_BUCKET = "newvelles-data-bucket"
+ARCHIVE_PREFIX = "newvelles_visualization_0.2.1_"
+DESTINATIONS = {
+    "qa": ("newvelles-qa-bucket", "public-newvelles-qa-bucket"),
+    "prod": ("newvelles-data-bucket", "public-newvelles-data-bucket"),
+}
+_STAMP_RE = re.compile(r"(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2})")
+
+
+def list_window_runs(s3_client) -> list:
+    """Archive keys for the last WINDOW_DAYS distinct dates, oldest first,
+    one run per minute-stamp (retries produce near-duplicate objects)."""
+    keys = []
+    for page in s3_client.get_paginator("list_objects_v2").paginate(
+        Bucket=SOURCE_ARCHIVE_BUCKET, Prefix=ARCHIVE_PREFIX
+    ):
+        keys.extend(o["Key"] for o in page.get("Contents", []))
+    keys.sort()
+
+    dated = []
+    seen_minutes = set()
+    for key in keys:
+        match = _STAMP_RE.search(key)
+        if not match:
+            continue
+        minute = match.group(1) + match.group(2)
+        if minute in seen_minutes:
+            continue
+        seen_minutes.add(minute)
+        dated.append((match.group(1), key))
+
+    dates = sorted({d for d, _ in dated})[-WINDOW_DAYS:]
+    return [(d, k) for d, k in dated if d in dates]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env", choices=sorted(DESTINATIONS), required=True)
+    parser.add_argument("--dry-run", action="store_true",
+                        help="write momentum.json/momentum_state.json locally instead of S3")
+    args = parser.parse_args()
+
+    s3_client = boto3.client("s3")
+    runs = list_window_runs(s3_client)
+    print(f"Replaying {len(runs)} archived runs across "
+          f"{len({d for d, _ in runs})} days from s3://{SOURCE_ARCHIVE_BUCKET}/")
+
+    state = None
+    momentum_doc = None
+    for run_date, key in runs:
+        body = s3_client.get_object(Bucket=SOURCE_ARCHIVE_BUCKET, Key=key)["Body"].read()
+        stories_data = build_stories(json.loads(body))
+        stories_data, momentum_doc, state = apply_momentum(stories_data, state, today=run_date)
+        carried = sum(1 for s in stories_data["stories"] if s.get("days_running", 1) > 1)
+        print(f"  {key[-25:-5]}: {stories_data['story_count']} stories, {carried} carried ids")
+
+    if momentum_doc is None:
+        print("No archived runs found in the window — nothing to seed.")
+        sys.exit(1)
+
+    multi_day = sum(1 for v in momentum_doc["stories"].values() if v["days_running"] > 1)
+    print(f"\nSeeded window {momentum_doc['window_start']} → {momentum_doc['window_end']}: "
+          f"{len(momentum_doc['stories'])} live stories, {multi_day} spanning multiple days, "
+          f"{len(state['stories'])} in state")
+
+    if args.dry_run:
+        Path("momentum_backfill.json").write_text(json.dumps(momentum_doc, indent=1))
+        Path("momentum_state_backfill.json").write_text(json.dumps(state, indent=1))
+        print("Dry run: wrote momentum_backfill.json + momentum_state_backfill.json locally")
+        return
+
+    private_bucket, public_bucket = DESTINATIONS[args.env]
+    upload_to_s3(bucket_name=private_bucket, file_name="momentum_state.json",
+                 string_byte=json.dumps(state).encode("utf-8"))
+    upload_to_s3(bucket_name=public_bucket, file_name="momentum.json",
+                 string_byte=json.dumps(momentum_doc).encode("utf-8"), public_read=True)
+    print(f"Uploaded momentum_state.json -> s3://{private_bucket}/ "
+          f"and momentum.json -> s3://{public_bucket}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backfill_momentum.py
+++ b/scripts/backfill_momentum.py
@@ -26,9 +26,9 @@ import boto3
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from newvelles.models.momentum import WINDOW_DAYS, apply_momentum  # noqa: E402
-from newvelles.models.stories import build_stories  # noqa: E402
-from newvelles.utils.s3 import upload_to_s3  # noqa: E402
+from newvelles.models.momentum import WINDOW_DAYS, apply_momentum  # noqa: E402  pylint: disable=wrong-import-position
+from newvelles.models.stories import build_stories  # noqa: E402  pylint: disable=wrong-import-position
+from newvelles.utils.s3 import upload_to_s3  # noqa: E402  pylint: disable=wrong-import-position
 
 SOURCE_ARCHIVE_BUCKET = "newvelles-data-bucket"
 ARCHIVE_PREFIX = "newvelles_visualization_0.2.1_"
@@ -96,8 +96,10 @@ def main() -> None:
           f"{len(state['stories'])} in state")
 
     if args.dry_run:
-        Path("momentum_backfill.json").write_text(json.dumps(momentum_doc, indent=1))
-        Path("momentum_state_backfill.json").write_text(json.dumps(state, indent=1))
+        Path("momentum_backfill.json").write_text(json.dumps(momentum_doc, indent=1),
+                                                  encoding="utf-8")
+        Path("momentum_state_backfill.json").write_text(json.dumps(state, indent=1),
+                                                        encoding="utf-8")
         print("Dry run: wrote momentum_backfill.json + momentum_state_backfill.json locally")
         return
 

--- a/test/test_feed_log.py
+++ b/test/test_feed_log.py
@@ -313,7 +313,8 @@ class TestEmitVisualization:
     def test_log_s3_delegates(self, mock_emit):
         mock_emit.return_value = "x.json"
         assert log_s3({}) == "x.json"
-        mock_emit.assert_called_once_with({}, writers="s3", stories_data=None)
+        mock_emit.assert_called_once_with({}, writers="s3", stories_data=None,
+                                          momentum_doc=None, momentum_state=None)
 
 
 class TestEmitStories:
@@ -364,3 +365,83 @@ class TestEmitStories:
         assert json.load(open(tmp_path / "latest" / "stories.json")) == stories
         assert json.load(open(tmp_path / "stories.json")) == stories
         mock_upload.assert_not_called()
+
+
+class TestEmitMomentum:
+    STORIES = {"version": "0.3.0", "story_count": 100, "article_count": 500, "stories": []}
+    MOMENTUM = {"version": "0.3.0", "generated": "2025-01-16T10:30:45", "window_days": 14,
+                "stories": {}}
+    STATE = {"version": "0.3.0", "updated": "2025-01-16", "stories": {}}
+
+    @patch("newvelles.feed.log.read_json_from_s3", return_value=None)
+    @patch("newvelles.feed.log.upload_to_s3")
+    @patch("newvelles.feed.log._current_datetime")
+    def test_momentum_uploads_after_stories(self, mock_datetime, mock_upload, mock_read):
+        from newvelles.feed.log import _S3_BUCKET, emit_visualization
+        mock_datetime.return_value = "2025-01-16T10:30:45"
+
+        emit_visualization({}, writers="s3", stories_data=self.STORIES,
+                           momentum_doc=self.MOMENTUM, momentum_state=self.STATE)
+
+        calls = mock_upload.call_args_list
+        names = [c.kwargs["file_name"] for c in calls]
+        assert names == [
+            "newvelles_visualization_0.2.1_2025-01-16T10:30:45.json",
+            "latest_news.json",
+            "latest_news_metadata.json",
+            "stories.json",
+            "momentum.json",
+            "momentum_state.json",
+        ]
+        momentum_call = calls[4]
+        assert momentum_call.kwargs["bucket_name"] == _S3_PUBLIC_BUCKET
+        assert momentum_call.kwargs["public_read"] is True
+        assert json.loads(momentum_call.kwargs["string_byte"]) == self.MOMENTUM
+        state_call = calls[5]
+        assert state_call.kwargs["bucket_name"] == _S3_BUCKET  # private
+        assert state_call.kwargs.get("public_read", False) is False
+
+    @patch("newvelles.feed.log.read_json_from_s3")
+    @patch("newvelles.feed.log.upload_to_s3")
+    @patch("newvelles.feed.log._current_datetime")
+    def test_blocked_gate_blocks_momentum_and_state_too(self, mock_datetime, mock_upload, mock_read):
+        """An anomalous run must not pollute the identity state."""
+        from newvelles.feed.log import emit_visualization
+        mock_datetime.return_value = "2025-01-16T10:30:45"
+        mock_read.return_value = {"story_count": 175}
+        bad = {"version": "0.3.0", "story_count": 400, "article_count": 500, "stories": []}
+
+        emit_visualization({}, writers="s3", stories_data=bad,
+                           momentum_doc=self.MOMENTUM, momentum_state=self.STATE)
+
+        names = [c.kwargs["file_name"] for c in mock_upload.call_args_list]
+        assert "stories.json" not in names
+        assert "momentum.json" not in names
+        assert "momentum_state.json" not in names
+
+    @patch("newvelles.feed.log.upload_to_s3")
+    @patch("newvelles.feed.log._current_datetime")
+    def test_local_writer_writes_momentum_and_state(self, mock_datetime, mock_upload,
+                                                    tmp_path, monkeypatch):
+        from newvelles.feed import log as log_mod
+        mock_datetime.return_value = "2025-01-16T10:30:45"
+        monkeypatch.setattr(log_mod, "_LATEST_PATH", str(tmp_path / "latest"))
+        monkeypatch.chdir(tmp_path)
+
+        log_mod.emit_visualization({}, writers="local", output_path=str(tmp_path / "logs"),
+                                   stories_data=self.STORIES,
+                                   momentum_doc=self.MOMENTUM, momentum_state=self.STATE)
+
+        assert json.load(open(tmp_path / "momentum.json")) == self.MOMENTUM
+        assert json.load(open(tmp_path / "latest" / "momentum.json")) == self.MOMENTUM
+        assert json.load(open(tmp_path / "cache" / "momentum_state.json")) == self.STATE
+        mock_upload.assert_not_called()
+
+    @patch("newvelles.feed.log.emit_visualization")
+    def test_log_s3_passes_momentum_through(self, mock_emit):
+        mock_emit.return_value = "x.json"
+        log_s3({}, stories_data=self.STORIES, momentum_doc=self.MOMENTUM,
+               momentum_state=self.STATE)
+        mock_emit.assert_called_once_with(
+            {}, writers="s3", stories_data=self.STORIES,
+            momentum_doc=self.MOMENTUM, momentum_state=self.STATE)

--- a/test/test_handler.py
+++ b/test/test_handler.py
@@ -61,13 +61,15 @@ class TestHandler:
 class TestRun:
     """Test run function."""
 
+    @patch("handler.load_state_s3")
+    @patch("handler.apply_momentum")
     @patch("handler.build_stories")
     @patch("handler.log_s3")
     @patch("handler.build_visualization")
     @patch("handler.build_data_from_rss_feeds_list")
     @patch("handler.CONFIG")
     def test_run_success(self, mock_config, mock_build_data, mock_build_viz, mock_log_s3,
-                         mock_build_stories):
+                         mock_build_stories, mock_apply, mock_load_state):
         """Test run function executes pipeline successfully."""
         # Mock configuration
         mock_config.__getitem__.return_value = {"cluster_limit": "5"}
@@ -82,6 +84,10 @@ class TestRun:
         mock_build_viz.return_value = (mock_visualization_data, mock_group_sentences)
         mock_stories = {"version": "0.3.0", "story_count": 0, "kind_counts": {}, "stories": []}
         mock_build_stories.return_value = mock_stories
+        mock_load_state.return_value = None
+        mock_momentum = {"version": "0.3.0", "stories": {}}
+        mock_state = {"version": "0.3.0", "stories": {}}
+        mock_apply.return_value = (mock_stories, mock_momentum, mock_state)
 
         result = run()
 
@@ -89,7 +95,12 @@ class TestRun:
         mock_build_data.assert_called_once()
         mock_build_viz.assert_called_once_with(mock_title_data, cluster_limit=5)
         mock_build_stories.assert_called_once_with(mock_visualization_data)
-        mock_log_s3.assert_called_once_with(mock_visualization_data, stories_data=mock_stories)
+        mock_load_state.assert_called_once()
+        assert mock_apply.call_args.args[0] is mock_stories
+        assert mock_apply.call_args.args[1] is None
+        mock_log_s3.assert_called_once_with(
+            mock_visualization_data, stories_data=mock_stories,
+            momentum_doc=mock_momentum, momentum_state=mock_state)
 
     @patch("handler.log_s3")
     @patch("handler.build_visualization")

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -12,6 +12,8 @@ from newvelles.__main__ import main, run, run_daemon
 class TestRun:
     """Test run function."""
 
+    @patch("newvelles.__main__.load_state_local", return_value=None)
+    @patch("newvelles.__main__.apply_momentum")
     @patch("newvelles.__main__.print_viz")
     @patch("newvelles.__main__.print_sorted_grouped_titles")
     @patch("newvelles.__main__.log_groups")
@@ -31,6 +33,8 @@ class TestRun:
         mock_log_groups,
         mock_print_titles,
         mock_print_viz,
+        mock_apply,
+        mock_load_state,
     ):
         """Test basic functionality of run function."""
         # Mock configuration
@@ -46,6 +50,9 @@ class TestRun:
         mock_build_viz.return_value = (mock_visualization_data, mock_group_sentences)
         mock_stories = {"version": "0.3.0", "stories": []}
         mock_build_stories.return_value = mock_stories
+        mock_momentum = {"version": "0.3.0", "stories": {}}
+        mock_state = {"version": "0.3.0", "stories": {}}
+        mock_apply.return_value = (mock_stories, mock_momentum, mock_state)
 
         rss_file = "test_rss.txt"
 
@@ -56,7 +63,8 @@ class TestRun:
         mock_build_viz.assert_called_once_with(mock_title_data, cluster_limit=2)
         mock_build_stories.assert_called_once_with(mock_visualization_data)
         mock_emit.assert_called_once_with(
-            mock_visualization_data, writers="local", stories_data=mock_stories
+            mock_visualization_data, writers="local", stories_data=mock_stories,
+            momentum_doc=mock_momentum, momentum_state=mock_state,
         )
         mock_log_groups.assert_called_once_with(mock_group_sentences)
 
@@ -64,6 +72,8 @@ class TestRun:
         mock_print_titles.assert_not_called()
         mock_print_viz.assert_not_called()
 
+    @patch("newvelles.__main__.load_state_local", return_value=None)
+    @patch("newvelles.__main__.apply_momentum")
     @patch("newvelles.__main__.print_viz")
     @patch("newvelles.__main__.print_sorted_grouped_titles")
     @patch("newvelles.__main__.log_groups")
@@ -83,6 +93,8 @@ class TestRun:
         mock_log_groups,
         mock_print_titles,
         mock_print_viz,
+        mock_apply,
+        mock_load_state,
     ):
         """Test run function with debug mode enabled."""
         # Mock configuration
@@ -97,6 +109,9 @@ class TestRun:
         mock_build_viz.return_value = (mock_visualization_data, mock_group_sentences)
         mock_stories = {"version": "0.3.0", "stories": []}
         mock_build_stories.return_value = mock_stories
+        mock_momentum = {"version": "0.3.0", "stories": {}}
+        mock_state = {"version": "0.3.0", "stories": {}}
+        mock_apply.return_value = (mock_stories, mock_momentum, mock_state)
 
         rss_file = "test_rss.txt"
 
@@ -108,7 +123,8 @@ class TestRun:
 
         # Verify S3 logging is enabled (writers="both" uploads and writes locally)
         mock_emit.assert_called_once_with(
-            mock_visualization_data, writers="both", stories_data=mock_stories
+            mock_visualization_data, writers="both", stories_data=mock_stories,
+            momentum_doc=mock_momentum, momentum_state=mock_state,
         )
 
     @patch("newvelles.__main__.build_data_from_rss_feeds")
@@ -121,7 +137,12 @@ class TestRun:
 
         with patch("newvelles.__main__.build_visualization") as mock_build_viz, patch(
             "newvelles.__main__.emit_visualization"
-        ), patch("newvelles.__main__.build_stories"), patch("newvelles.__main__.log_groups"):
+        ), patch("newvelles.__main__.build_stories"), patch(
+            "newvelles.__main__.apply_momentum",
+            return_value=({}, {}, {}),
+        ), patch("newvelles.__main__.load_state_local", return_value=None), patch(
+            "newvelles.__main__.log_groups"
+        ):
 
             mock_build_viz.return_value = ({}, {})
 

--- a/test/test_models_momentum.py
+++ b/test/test_models_momentum.py
@@ -1,0 +1,175 @@
+"""Tests for newvelles.models.momentum — cross-run story identity and the 14-day rollup."""
+
+import pytest
+
+from newvelles.models.momentum import (CARRY_THRESHOLD, WINDOW_DAYS, apply_momentum,
+                                       derive_trend)
+
+
+def _story(sid, keywords, entities, outlets=3, articles=6):
+    return {
+        "id": sid,
+        "headline": f"headline {sid}",
+        "keywords": keywords,
+        "entities": entities,
+        "outlet_count": outlets,
+        "article_count": articles,
+        "days_running": 1,
+        "first_seen": "",
+        "kind": "story",
+    }
+
+
+def _doc(stories):
+    return {"version": "0.3.0", "story_count": len(stories),
+            "article_count": sum(s["article_count"] for s in stories), "stories": stories}
+
+
+ALASKA = _story("st_aaa111", ["alaska summit", "ceasefire"], ["Trump", "Putin", "Alaska"],
+                outlets=10, articles=20)
+MARKETS = _story("st_bbb222", ["fed rates"], ["Federal Reserve", "Powell"], outlets=4, articles=7)
+
+
+class TestIdentityCarry:
+    def test_two_day_carry_death_and_birth(self):
+        # Day 1: alaska + markets
+        d1, mom1, state1 = apply_momentum(_doc([dict(ALASKA), dict(MARKETS)]), None, "2026-08-15")
+        assert set(mom1["stories"]) == {"st_aaa111", "st_bbb222"}
+        assert all(v["trend"] == "new" for v in mom1["stories"].values())
+
+        # Day 2: alaska persists under a NEW fingerprint id; markets died; tech is born
+        alaska_day2 = _story("st_ccc333", ["alaska summit", "ceasefire", "zelensky"],
+                             ["Trump", "Putin", "Alaska", "Zelensky"], outlets=14, articles=30)
+        tech = _story("st_ddd444", ["pixel event"], ["Google"], outlets=2, articles=4)
+        d2, mom2, state2 = apply_momentum(_doc([alaska_day2, tech]), state1, "2026-08-16")
+
+        # carried: the day-2 alaska story now carries the day-1 id
+        carried = d2["stories"][0]
+        assert carried["id"] == "st_aaa111"
+        assert carried["days_running"] == 2
+        assert carried["first_seen"] == "2026-08-15"
+        entry = mom2["stories"]["st_aaa111"]
+        assert [p["date"] for p in entry["series"]] == ["2026-08-15", "2026-08-16"]
+        assert entry["series"][1]["outlets"] == 14
+        # died: markets absent from the doc but retained in state for the window
+        assert "st_bbb222" not in mom2["stories"]
+        assert "st_bbb222" in state2["stories"]
+        # born: fresh id, new trend
+        assert mom2["stories"]["st_ddd444"]["trend"] == "new"
+
+    def test_same_day_second_run_takes_max_and_keeps_id(self):
+        d1, _, state1 = apply_momentum(_doc([dict(ALASKA)]), None, "2026-08-15")
+        # later run same day: fewer outlets in this fetch, more articles
+        again = _story("st_eee555", ["alaska summit", "ceasefire"], ["Trump", "Putin", "Alaska"],
+                       outlets=7, articles=25)
+        d2, mom2, state2 = apply_momentum(_doc([again]), state1, "2026-08-15")
+        assert d2["stories"][0]["id"] == "st_aaa111"
+        series = mom2["stories"]["st_aaa111"]["series"]
+        assert len(series) == 1  # still one datapoint for the day
+        assert series[0]["outlets"] == 10   # max(10, 7) — a day records its peak
+        assert series[0]["articles"] == 25  # max(20, 25)
+        assert d2["stories"][0]["days_running"] == 1
+
+    def test_skipped_day_mints_new_id(self):
+        _, _, state1 = apply_momentum(_doc([dict(ALASKA)]), None, "2026-08-13")
+        # story absent on the 14th; returns on the 15th -> matching window is yesterday only
+        returns = _story("st_fff666", ["alaska summit", "ceasefire"],
+                         ["Trump", "Putin", "Alaska"])
+        d3, mom3, _ = apply_momentum(_doc([returns]), state1, "2026-08-15")
+        assert d3["stories"][0]["id"] == "st_fff666"
+        assert mom3["stories"]["st_fff666"]["trend"] == "new"
+
+    def test_one_to_one_matching_prefers_best_score(self):
+        _, _, state1 = apply_momentum(_doc([dict(ALASKA)]), None, "2026-08-15")
+        strong = _story("st_ggg777", ["alaska summit", "ceasefire"],
+                        ["Trump", "Putin", "Alaska"])          # high overlap
+        weak = _story("st_hhh888", ["alaska summit"], ["Alaska", "Anchorage", "Tourism"])
+        d2, _, _ = apply_momentum(_doc([weak, strong]), state1, "2026-08-16")
+        by_headline = {s["headline"]: s["id"] for s in d2["stories"]}
+        assert by_headline["headline st_ggg777"] == "st_aaa111"  # best match carries the id
+        assert by_headline["headline st_hhh888"] == "st_hhh888"  # loser keeps its own id
+
+    def test_below_threshold_does_not_carry(self):
+        _, _, state1 = apply_momentum(_doc([dict(ALASKA)]), None, "2026-08-15")
+        unrelated = _story("st_iii999", ["earnings"], ["Acme Corp"])
+        d2, _, _ = apply_momentum(_doc([unrelated]), state1, "2026-08-16")
+        assert d2["stories"][0]["id"] == "st_iii999"
+
+
+class TestWindow:
+    def test_series_never_exceeds_window(self):
+        state = None
+        stories_doc = None
+        for day in range(1, 17):  # 16 consecutive days
+            persistent = _story(f"st_day{day:02}", ["alaska summit", "ceasefire"],
+                                ["Trump", "Putin", "Alaska"], outlets=day)
+            stories_doc, mom, state = apply_momentum(_doc([persistent]), state,
+                                                     f"2026-08-{day:02}")
+        entry = list(mom["stories"].values())[0]
+        assert len(entry["series"]) <= WINDOW_DAYS
+        assert entry["series"][-1]["date"] == "2026-08-16"
+        assert mom["window_days"] == WINDOW_DAYS
+        assert mom["window_start"] == "2026-08-03"
+        assert mom["window_end"] == "2026-08-16"
+
+    def test_state_prunes_stories_outside_window(self):
+        _, _, state = apply_momentum(_doc([dict(ALASKA)]), None, "2026-08-01")
+        for day in range(2, 17):
+            other = _story(f"st_x{day:02}", [f"kw{day}"], [f"Ent{day}"])
+            _, _, state = apply_momentum(_doc([other]), state, f"2026-08-{day:02}")
+        assert "st_aaa111" not in state["stories"]  # last seen 2026-08-01, outside window
+
+
+class TestTrend:
+    def _series(self, *outlets, start_day=1):
+        return [{"date": f"2026-08-{start_day + i:02}", "outlets": o, "articles": o * 2}
+                for i, o in enumerate(outlets)]
+
+    def test_single_datapoint_is_new(self):
+        assert derive_trend(self._series(5), "2026-08-01") == "new"
+
+    def test_climbing(self):
+        s = self._series(3, 5, 9)
+        assert derive_trend(s, "2026-08-03") == "climbing"
+
+    def test_peaked_yesterday(self):
+        s = self._series(3, 12, 6)
+        assert derive_trend(s, "2026-08-02") == "peaked"
+
+    def test_cooling(self):
+        s = self._series(12, 9, 4, 2)
+        assert derive_trend(s, "2026-08-01") == "cooling"
+
+    def test_steady(self):
+        s = self._series(5, 5, 5)
+        assert derive_trend(s, "2026-08-01") == "steady"
+
+
+class TestDocShape:
+    def test_doc_contains_only_current_story_ids(self):
+        _, _, state1 = apply_momentum(_doc([dict(ALASKA), dict(MARKETS)]), None, "2026-08-15")
+        only_alaska = _story("st_jjj000", ["alaska summit", "ceasefire"],
+                             ["Trump", "Putin", "Alaska"])
+        _, mom2, _ = apply_momentum(_doc([only_alaska]), state1, "2026-08-16")
+        assert set(mom2["stories"]) == {"st_aaa111"}
+
+    def test_first_run_from_none_state(self):
+        d, mom, state = apply_momentum(_doc([dict(ALASKA)]), None, "2026-08-15")
+        assert mom["version"] == "0.3.0"
+        assert d["stories"][0]["first_seen"] == "2026-08-15"
+        assert state["stories"]["st_aaa111"]["last_seen"] == "2026-08-15"
+
+    def test_peak_date_is_earliest_max(self):
+        state = None
+        outlets_by_day = {15: 4, 16: 9, 17: 9}
+        for day, o in outlets_by_day.items():
+            s = _story(f"st_p{day}", ["alaska summit", "ceasefire"],
+                       ["Trump", "Putin", "Alaska"], outlets=o)
+            _, mom, state = apply_momentum(_doc([s]), state, f"2026-08-{day}")
+        entry = list(mom["stories"].values())[0]
+        assert entry["peak_date"] == "2026-08-16"  # earliest occurrence of the max
+
+
+def test_carry_threshold_constant():
+    assert CARRY_THRESHOLD == 0.4
+    assert WINDOW_DAYS == 14

--- a/test/test_momentum_schema.py
+++ b/test/test_momentum_schema.py
@@ -1,0 +1,66 @@
+"""Schema validation for momentum.json (v0.3.0) — contract fixture and generated output."""
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from newvelles.models.momentum import apply_momentum
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def schema():
+    return json.loads((REPO_ROOT / "schemas" / "momentum_schema.json").read_text())
+
+
+def _fixture():
+    return json.loads((REPO_ROOT / "test" / "fixtures" / "momentum_v0.3.0.json").read_text())
+
+
+def _generated_doc():
+    story = {"id": "st_abc123", "headline": "h", "keywords": ["alaska summit"],
+             "entities": ["Trump"], "outlet_count": 5, "article_count": 9,
+             "days_running": 1, "first_seen": "", "kind": "story"}
+    doc = {"version": "0.3.0", "generated": "2026-08-15T12:00:00",
+           "story_count": 1, "article_count": 9, "stories": [story]}
+    _, mom, state = apply_momentum(doc, None, "2026-08-15")
+    story2 = dict(story, id="st_zzz999", outlet_count=8, article_count=15)
+    doc2 = {"version": "0.3.0", "generated": "2026-08-16T12:00:00",
+            "story_count": 1, "article_count": 15, "stories": [story2]}
+    _, mom2, _ = apply_momentum(doc2, state, "2026-08-16")
+    return mom2
+
+
+def test_contract_fixture_validates(schema):
+    jsonschema.validate(_fixture(), schema)
+
+
+def test_generated_momentum_validates(schema):
+    jsonschema.validate(_generated_doc(), schema)
+
+
+def test_schema_rejects_missing_trend(schema):
+    fixture = _fixture()
+    story = next(iter(fixture["stories"].values()))
+    del story["trend"]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(fixture, schema)
+
+
+def test_schema_rejects_unknown_trend(schema):
+    fixture = _fixture()
+    story = next(iter(fixture["stories"].values()))
+    story["trend"] = "skyrocketing"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(fixture, schema)
+
+
+def test_schema_rejects_empty_series(schema):
+    fixture = _fixture()
+    story = next(iter(fixture["stories"].values()))
+    story["series"] = []
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(fixture, schema)


### PR DESCRIPTION
## Summary

Stage C / M4: momentum. Stories now keep their identity across runs and days, and a public `momentum.json` carries a rolling 14-day series per live story — the data behind the sparklines, "running N days" counters, and trend labels. QA and production buckets are already seeded with a real 14-day window replayed from the archive.

## Changes

- **Identity carry** (`newvelles/models/momentum.py`) — pure `apply_momentum(stories_data, state, today)`: matches each story against stories last seen today/yesterday via Jaccard over keywords ∪ entities (threshold **0.4**, one-to-one, best-score-first); a match inherits the previous story id, `first_seen`, and `days_running`. No match mints a new id.
- **Rolling window** — per-day datapoint records the day's peak (`max(outlets)`, `max(articles)` across that day's four runs); only the current day ever mutates; series and state trim to 14 days.
- **Trend derivation** — `new | climbing | peaked | cooling | steady`, derived not stored; the vocabulary is a UI contract (printed verbatim under sparklines). Schema additionally tolerates the fixture-only `"single day"`.
- **Two artifacts behind the sanity gate** — `momentum.json` (public; only ids present in the current `stories.json`, ~51KB) and `momentum_state.json` (private; full window for matching). A gate-blocked run publishes neither and does not pollute identity state.
- **Backfill** (`scripts/backfill_momentum.py`, `make backfill-momentum ENV=qa|prod`) — replays the last 14 days of archived production runs through the identical pipeline. **Already executed:** both QA and production buckets carry a seeded window (2026-08-04 → 2026-08-17; 180 live stories, 143 spanning multiple days, all five trend values present). The QA archive itself was stale (last real runs April 2026), so the production archive is the source for both.
- Schema: `schemas/momentum_schema.json`, validated against the contract fixture `test/fixtures/momentum_v0.3.0.json`.

## Testing

- 392 passed, 0 failed; pylint 10.00/10, flake8 clean
- 21 new momentum tests: two-day carry/death/birth, same-day max rule, skipped-day re-mint, one-to-one best-match assignment, window trim over 16 simulated days, all five trend cases, peak-date tie-breaking, doc shape
- Live verification: two consecutive CLI runs on real RSS — state holds exactly 32 stories after both (zero id churn; a carry failure would have doubled it), all 32 stories join their momentum entries, output schema-valid
- Backfill dry-run inspected before seeding: 13-day series with believable declining sparkline on the longest-running story

## Notes for review

- M4's definition of done ("momentum.json in QA with a seeded 14-day window; ids survive a simulated two-day run") is met — but the QA seed comes from production archives, since the QA Lambda hasn't run since April.
- Deviation from spec (flagged in the plan): public `momentum.json` is filtered to current stories only. The full window lives in the private state. This matches the fixture (which carries exactly its 41 current stories) and keeps the public file in kilobytes.
- Deploy note: after this merges, the next `qa-deploy`/`prod-deploy` picks it up; the seeded state means day one already shows multi-day sparklines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
