### PR TITLE
Naming prompt tuning: never let meta-commentary reach the site as a headline

### DIFF
--- a/newvelles/models/naming.py
+++ b/newvelles/models/naming.py
@@ -37,6 +37,11 @@ Write one plain sentence naming what happened. Rules:
 - Use the names of people, places and organisations that appear
 - If the headlines disagree about what happened, name the disputed
   fact, not one side's version
+- If the headlines cover several unrelated items, ignore all but one:
+  write your sentence about the single item with the most headlines,
+  breaking ties in favour of headline 1. Never describe or evaluate the
+  headlines themselves, and never say they are unrelated or cannot be
+  combined — your reply must always be about a news event, nothing else.
 
 Headlines:
 {headlines}
@@ -53,6 +58,22 @@ def build_prompt(story: dict) -> str:
     return PROMPT_TEMPLATE.format(headlines="\n".join(lines))
 
 
+# A refusal to name an incoherent cluster must never reach the site as a
+# "headline" — reject meta-commentary so the story keeps its real headline.
+# Observed live in the first QA run ("These headlines appear to cover
+# different events and cannot be combined into a single news story name").
+_META_RESPONSE_MARKERS = (
+    "these headlines", "the headlines", "headlines provided", "i cannot",
+    "cannot be combined", "unable to determine", "unrelated to a single",
+    "single news story name", "as an ai",
+    # generic "no common event" phrasings — for a truly incoherent cluster the
+    # right outcome is the real-headline fallback, not a synthetic summary
+    "articles cover", "articles covered", "without a common", "no single event",
+    "no common event", "different topics", "various topics", "multiple topics",
+    "unrelated items", "unrelated stories", "unrelated events",
+)
+
+
 def _postprocess(text: str) -> str:
     """First line, stripped of quotes/whitespace/trailing period; reject junk."""
     line = text.strip().splitlines()[0].strip() if text.strip() else ""
@@ -61,6 +82,10 @@ def _postprocess(text: str) -> str:
         raise ValueError("empty headline from provider")
     if len(line) > MAX_HEADLINE_CHARS:
         raise ValueError(f"headline too long ({len(line)} chars)")
+    lowered = line.lower()
+    for marker in _META_RESPONSE_MARKERS:
+        if marker in lowered:
+            raise ValueError(f"meta-commentary instead of a headline: {line[:60]!r}")
     return line
 
 

--- a/test/test_models_naming.py
+++ b/test/test_models_naming.py
@@ -40,6 +40,9 @@ class TestBuildPrompt:
         prompt = build_prompt(_story(ALASKA_TITLES))
         assert "6 to 12 words" in prompt
         assert "Reply with the sentence and nothing else." in prompt
+        # incoherent-cluster instruction: name the dominant event, never comment on the input
+        assert "the single item with the most headlines" in prompt
+        assert "Never describe or evaluate the" in prompt
         for title, outlet in ALASKA_TITLES:
             assert title in prompt
             assert outlet in prompt
@@ -71,6 +74,25 @@ class TestPostprocess:
     def test_empty_raises(self):
         with pytest.raises(ValueError):
             _postprocess("   \n ")
+
+    @pytest.mark.parametrize("meta", [
+        "These headlines appear to cover different events and cannot be combined",
+        "These headlines are primarily product recommendations and shopping guides",
+        "The headlines describe unrelated stories",
+        "I cannot name this story as one event",
+        "Unable to determine a single event from the provided headlines",
+        "Articles covered different technology topics without a common event",
+        "Coverage spans various topics with no single event",
+    ])
+    def test_meta_commentary_rejected(self, meta):
+        """A refusal to name the cluster must fall back to a real headline,
+        never reach the site as a 'headline'. Observed live in the first QA run."""
+        with pytest.raises(ValueError):
+            _postprocess(meta)
+
+    def test_legitimate_headline_mentioning_news_is_kept(self):
+        assert _postprocess("Newspaper industry faces steep advertising decline") \
+            == "Newspaper industry faces steep advertising decline"
 
     def test_too_long_raises(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
The first QA run with live Haiku naming surfaced the failure mode the delivery plan budgeted prompt-tuning for: **4 of 30 headlines were the model commenting on incoherent clusters** ("These headlines appear to cover different events and cannot be combined...") instead of naming an event.

## Changes
- **Prompt**: new rule — for clusters covering several unrelated items, write about the single item with the most headlines (tie-break to headline 1); never describe or evaluate the headlines, never say they can't be combined.
- **Postprocess guard**: rejects meta-commentary patterns ("these headlines", "no common event", "different topics", ...) with ValueError, so the story keeps its real-headline fallback. Defense in depth — even if the prompt fails, meta text can never reach the site.

## Testing
- 36 naming tests (7 new meta-rejection cases incl. both observed live responses); full suite green; pylint 10.00/10
- **Live re-verification**: all 4 incoherent QA clusters re-named against real Bedrock — every one now yields a genuine event name (e.g. "Astronomers discover a previously unknown type of star involving a black hole")

## Rollout note
QA's naming cache currently holds the 4 bad headlines; deploying this and clearing `story_names.json` in the QA private bucket forces clean re-naming (I'll do that at QA deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)