### PR TITLE
Deploys must preserve naming env vars (prod incident follow-up)

### DIFF
--- a/bin/deploy-to-environment.sh
+++ b/bin/deploy-to-environment.sh
@@ -36,21 +36,21 @@ fi
 case $ENVIRONMENT in
     "prod"|"production")
         LAMBDA_FUNCTION="RunNewvelles"
-        ENV_VARS='Variables={}'
+        ENV_VARS='Variables={"NEWVELLES_NAMING_PROVIDER":"bedrock","NEWVELLES_NAMING_MODEL":"us.anthropic.claude-haiku-4-5-20251001-v1:0"}'
         S3_PRIVATE="newvelles-data-bucket"
         S3_PUBLIC="public-newvelles-data-bucket"
         echo "🏭 Deploying to PRODUCTION environment"
         ;;
     "qa"|"shadow")
         LAMBDA_FUNCTION="RunNewvelles-qa"
-        ENV_VARS='Variables={"AWS_S3_BUCKET":"newvelles-qa-bucket","AWS_S3_PUBLIC_BUCKET":"public-newvelles-qa-bucket"}'
+        ENV_VARS='Variables={"AWS_S3_BUCKET":"newvelles-qa-bucket","AWS_S3_PUBLIC_BUCKET":"public-newvelles-qa-bucket","NEWVELLES_NAMING_PROVIDER":"bedrock","NEWVELLES_NAMING_MODEL":"us.anthropic.claude-haiku-4-5-20251001-v1:0"}'
         S3_PRIVATE="newvelles-qa-bucket"
         S3_PUBLIC="public-newvelles-qa-bucket"
         echo "🛡️ Deploying to QA/Shadow environment"
         ;;
     "test"|"testing")
         LAMBDA_FUNCTION="RunNewvelles-test"
-        ENV_VARS='Variables={"AWS_S3_BUCKET":"newvelles-test-bucket","AWS_S3_PUBLIC_BUCKET":"public-newvelles-test-bucket"}'
+        ENV_VARS='Variables={"AWS_S3_BUCKET":"newvelles-test-bucket","AWS_S3_PUBLIC_BUCKET":"public-newvelles-test-bucket","NEWVELLES_NAMING_PROVIDER":"bedrock","NEWVELLES_NAMING_MODEL":"us.anthropic.claude-haiku-4-5-20251001-v1:0"}'
         S3_PRIVATE="newvelles-test-bucket"
         S3_PUBLIC="public-newvelles-test-bucket"
         echo "🧪 Deploying to TESTING environment"

--- a/handler.py
+++ b/handler.py
@@ -101,8 +101,9 @@ def run() -> bool:
     naming_cache = load_naming_cache_s3()
     stories_data, naming_cache, naming_stats = name_stories(stories_data, naming_cache)
     save_naming_cache_s3(naming_cache)
-    print(f"✏️ Naming: {naming_stats['llm_named']} named, {naming_stats['cache_hits']} cached, "
-          f"{naming_stats['renamed']} renamed, {naming_stats['fallbacks']} fallbacks")
+    print(f"✏️ Naming: {naming_stats['llm_named']} llm, {naming_stats['local_named']} local, "
+          f"{naming_stats['cache_hits']} cached, {naming_stats['renamed']} renamed, "
+          f"{naming_stats['fallbacks']} fallbacks")
 
     print("📤 Uploading to S3...")
     log_s3(visualization_data, stories_data=stories_data,

--- a/newvelles/models/naming.py
+++ b/newvelles/models/naming.py
@@ -238,7 +238,7 @@ def name_stories(
     provider_name = provider_name or resolve_provider()
     today = today or date.today().isoformat()
     stories = stories_data.get("stories", [])
-    stats = {"llm_named": 0, "cache_hits": 0, "fallbacks": 0, "renamed": 0}
+    stats = {"llm_named": 0, "local_named": 0, "cache_hits": 0, "fallbacks": 0, "renamed": 0}
 
     to_name = []
     for story in stories:
@@ -278,6 +278,8 @@ def name_stories(
             stats["renamed"] += 1
         if source == "llm":
             stats["llm_named"] += 1
+        else:
+            stats["local_named"] += 1
         story["headline"] = headline
         story["headline_source"] = source
         new_cache[story["id"]] = {

--- a/test/test_handler.py
+++ b/test/test_handler.py
@@ -93,7 +93,7 @@ class TestRun:
         mock_state = {"version": "0.3.0", "stories": {}}
         mock_apply.return_value = (mock_stories, mock_momentum, mock_state)
         mock_name.return_value = (mock_stories, {},
-                                  {"llm_named": 0, "cache_hits": 0,
+                                  {"llm_named": 0, "local_named": 0, "cache_hits": 0,
                                    "fallbacks": 0, "renamed": 0})
 
         result = run()

--- a/test/test_models_naming.py
+++ b/test/test_models_naming.py
@@ -204,7 +204,7 @@ class TestNameStories:
         assert story["headline_source"] == "llm"
         assert cache["st_abc123"]["headline"] == "Generated headline number 1"
         assert cache["st_abc123"]["article_count"] == 3
-        assert stats == {"llm_named": 1, "cache_hits": 0, "fallbacks": 0, "renamed": 0}
+        assert stats == {"llm_named": 1, "local_named": 0, "cache_hits": 0, "fallbacks": 0, "renamed": 0}
 
     def test_cache_hit_prevents_second_call(self):
         from newvelles.models.naming import name_stories


### PR DESCRIPTION
## What happened
First production deploy of M3: `bin/deploy-to-environment.sh prod` sets `Variables={}` ('config file defaults'), which **wiped** the `NEWVELLES_NAMING_PROVIDER`/`MODEL` vars staged on the Lambda. One run published correctly with Bedrock (60 Haiku names), then the deploy's config update landed, and subsequent runs silently fell back to the `local` spaCy provider — polluting the naming cache with 113 machine-composed names. The stats line masked it: local successes weren't counted anywhere, so logs read '0 named' while the cache grew.

## Fixes
- `bin/deploy-to-environment.sh`: all three environments (prod/qa/test) now include the naming vars in the env they set, so deploys can't wipe them.
- `naming.py`/`handler.py`: stats gain `local_named`; the log line now reads `N llm, N local, N cached, N renamed, N fallbacks` — a silent provider downgrade is visible at a glance.

## Already remediated live (no action needed)
- Prod env vars restored (verified on the function)
- Prod `story_names.json` purged of the 113 local entries (60 genuine Haiku entries kept)
- Clean Bedrock re-run verification below in PR comments

428 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)